### PR TITLE
[Security] Add missing use statement in #[IsGranted] example

### DIFF
--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -21,6 +21,7 @@ and ``#[IsGranted()]`` attribute also accept an
         namespace App\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\Security\Http\Attribute\IsGranted;
         use Symfony\Component\ExpressionLanguage\Expression;
         use Symfony\Component\HttpFoundation\Response;
 


### PR DESCRIPTION
The page [Using Expressions in Security Access Controls](https://symfony.com/doc/current/security/expressions.html) shows an example of how to use the `#[IsGranted]` attribute (example added in #17148). However, the example code is lacking the use statement for the IsGranted attribute.